### PR TITLE
Transactions updates

### DIFF
--- a/src/clj/hub/transactions.clj
+++ b/src/clj/hub/transactions.clj
@@ -67,18 +67,11 @@
   (let [[month _ year] (string/split (:Date tx) #"/")]
     (str year "-" (leading-zero month))))
 
-(defn update-all
-  "Apply `f` to each value in `m`."
-  [f m]
-  (reduce (fn [acc [k xs]]
-            (assoc acc k (f xs)))
-          {} m))
-
 (defn monthly-breakdown [txs]
   (->> txs
        (group-by month)
-       (update-all #(group-by :Category %))
-       (update-all totals)))
+       (util/update-vals #(group-by :Category %))
+       (util/update-vals totals)))
 
 (defn category-over-time [txs category]
   (->> txs
@@ -102,9 +95,9 @@
                               :home
                               :car]]
     (->> (monthly-breakdown txs)
-         (update-all (fn [xs]
-                       (->> (map #(get xs % 0) mandatory-categories)
-                            (reduce +))))
+         (util/update-vals (fn [xs]
+                             (->> (map #(get xs % 0) mandatory-categories)
+                                  (reduce +))))
          sort))
 
   (-> (monthly-breakdown txs)

--- a/src/clj/hub/transactions.clj
+++ b/src/clj/hub/transactions.clj
@@ -24,20 +24,18 @@
        (filter identity)
        first))
 
-(defn categorize
-  "Derive :Category for `tx`, matched by name as specified in `categories.edn`"
+(defn category
+  "Determine category for `tx` as specified by groupings in config."
   [tx config]
-  (assoc tx :Category
-         (or (when (seq (:Credit tx)) :income)
-             (categorize* tx config)
-             :uncategorized)))
+  (or (when (seq (:Credit tx)) :income)
+      (categorize* tx config)
+      :uncategorized))
 
 (defn process-tx
   "Format existing values and derive new values for `tx` map"
   [tx config]
-  (-> tx
-      (update :Description #(remove-prefix % config))
-      (categorize config)))
+  (let [formatted (update tx :Description #(remove-prefix % config))]
+    (assoc formatted :Category (category formatted config))))
 
 (defn total
   "Get net change to account for transaction."

--- a/src/clj/hub/transactions.clj
+++ b/src/clj/hub/transactions.clj
@@ -15,20 +15,15 @@
             (util/remove-prefix acc prefix))
           s prefixes))
 
-(defn categorize* [tx {:keys [categories]}]
-  (->> (for [[category members] categories]
-         (for [member members]
-           (when (string/starts-with? (:Description tx) member)
-             category)))
-       flatten
-       (filter identity)
-       first))
-
 (defn category
   "Determine category for `tx` as specified by groupings in config."
-  [tx config]
+  [tx {:keys [categories]}]
   (or (when (seq (:Credit tx)) :income)
-      (categorize* tx config)
+      (->> (for [[category members] categories]
+             (for [member members]
+               (when (string/starts-with? (:Description tx) member)
+                 category)))
+           flatten (filter identity) first)
       :uncategorized))
 
 (defn process-tx

--- a/src/clj/hub/transactions.clj
+++ b/src/clj/hub/transactions.clj
@@ -27,12 +27,20 @@
     (str year "-" (leading-zero month) "-" (leading-zero day))))
 
 (defn category
-  "Determine category for `tx` as specified by groupings in config."
+  "Determine category for `tx` as specified by groupings in config.
+
+  Entries in config must be either a string prefix, or a parse-able regex.
+  Regexes will apply to the beginning of the string (no need for ^ )
+
+  I had issues with escaping whitespace, e.g. \s, in the regex. This gave a
+  parse error because s is not a valid escape character. \\s gives a different
+  error in that it just shows as a literal? Not sure what that's about. I just
+  avoided it."
   [tx {:keys [categories]}]
-  (or (when (seq (:Credit tx)) :income)
-      (->> (for [[category members] categories]
+  (or (->> (for [[category members] categories]
              (for [member members]
-               (when (string/starts-with? (:Description tx) member)
+               (when (or (string/starts-with? (:Description tx) member)
+                         (re-find (re-pattern (str "^" member)) (:Description tx)))
                  category)))
            flatten (filter identity) first)
       :uncategorized))

--- a/src/clj/hub/transactions.clj
+++ b/src/clj/hub/transactions.clj
@@ -9,12 +9,11 @@
   (string/starts-with? (:Description tx) substr))
 
 (defn remove-prefix
-  "Remove prefixes from `tx` description, loaded from `prefixes.edn`."
-  [tx {:keys [prefixes]}]
+  "Remove all prefixes from string, in order."
+  [s {:keys [prefixes]}]
   (reduce (fn [acc prefix]
-            (update acc :Description
-                    #(util/remove-prefix % prefix)))
-          tx prefixes))
+            (util/remove-prefix acc prefix))
+          s prefixes))
 
 (defn categorize* [tx {:keys [categories]}]
   (->> (for [[category members] categories]
@@ -36,7 +35,9 @@
 (defn process-tx
   "Format existing values and derive new values for `tx` map"
   [tx config]
-  (-> tx (remove-prefix config) (categorize config)))
+  (-> tx
+      (update :Description #(remove-prefix % config))
+      (categorize config)))
 
 (defn total
   "Get net change to account for transaction."
@@ -88,7 +89,7 @@
 
 (comment
   (def config {:categories (load-edn "categories.edn")
-               :prefixes   (load-edn "prefixes.edn")})
+               :prefixes   (sort-by count > (load-edn "prefixes.edn"))})
   (def txs
     (->> (load-csv "transactions.csv")
          #_(filter (comp empty? :Credit))  ; only care about spending

--- a/src/clj/hub/util.clj
+++ b/src/clj/hub/util.clj
@@ -22,6 +22,13 @@
     (string/triml (string/replace-first s prefix ""))
     s))
 
+(defn update-vals
+  "Apply `f` to each value in `m`."
+  [f m]
+  (reduce (fn [acc [k xs]]
+            (assoc acc k (f xs)))
+          {} m))
+
 (defmacro swallow-exception
   {:style/indent 1}
   [pred & body]

--- a/test/clj/hub/transactions_test.clj
+++ b/test/clj/hub/transactions_test.clj
@@ -1,0 +1,16 @@
+(ns hub.transactions-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [hub.transactions :as sut]))
+
+(deftest process-tx
+  (testing "removes prefix"
+    (is (= {:Description "just this left"
+            :Category    :uncategorized}
+           (sut/process-tx {:Description "VENDOR *just this left"}
+                           {:prefixes ["VENDOR *"]}))))
+  (testing "adds category"
+    (is (= {:Description "gas station" :Category :car}
+           (sut/process-tx {:Description "gas station"}
+                           {:categories {:home #{"IKEA"}
+                                         :car  #{"gas"}}})))))

--- a/test/clj/hub/transactions_test.clj
+++ b/test/clj/hub/transactions_test.clj
@@ -25,3 +25,29 @@
 (deftest month
   (testing "extracts YYYY-MM format from `tx` date"
     (is (= "2022-02" (sut/month {:Date "2022-02-20"})))))
+
+(deftest remove-categories
+  (testing "removes two categories"
+    (is (= [{:Category :third}]
+           (sut/remove-categories [{:Category :first}
+                                   {:Category :second}
+                                   {:Category :third}]
+                                  :first :second)))))
+
+(deftest remove-shared-transactions
+  (testing "removes transfers from checking to savings. Identified by category"
+    (let [savings  [{:Date "2021-28-05" :Debit "" :Credit "0.05" :Category :banking}
+                    {:Date "2021-05-17" :Debit "" :Credit "574.79" :Category :transfers-from-checking}]
+          checking [{:Date "2021-05-17" :Debit "574.79" :Credit "" :Category :transfers-to-savings}
+                    {:Date "2021-07-26" :Debit "14.22" :Credit "" :Category :groceries}]]
+      (is (= {:savings  [{:Date "2021-28-05" :Debit "" :Credit "0.05" :Category :banking}]
+              :checking [{:Date "2021-07-26" :Debit "14.22" :Credit "" :Category :groceries}]}
+             (sut/remove-shared-transactions checking savings)))))
+  (testing "removes transfers from savings to checking. Have to match."
+    (let [savings  [{:Date "2021-07-26" :Debit "300.00" :Credit "" :Category :transfers-out-of-savings}
+                    {:Date "2021-28-05" :Debit "" :Credit "0.05" :Category :banking}]
+          checking [{:Date "2021-07-26" :Debit "" :Credit "300.00" :Category :transfers-from-savings}
+                    {:Date "2021-07-26" :Debit "14.22" :Credit "" :Category :groceries}]]
+      (is (= {:savings  [{:Date "2021-28-05" :Debit "" :Credit "0.05" :Category :banking}]
+              :checking [{:Date "2021-07-26" :Debit "14.22" :Credit "" :Category :groceries}]}
+             (sut/remove-shared-transactions checking savings))))))

--- a/test/clj/hub/transactions_test.clj
+++ b/test/clj/hub/transactions_test.clj
@@ -9,6 +9,14 @@
 (def base-description "gas station")
 (def description (str prefix base-description))
 
+(deftest category
+  (testing "returns first member that matches starting of tx string"
+    (is (= :expected (sut/category {:Description "an expected value"}
+                                   {:categories {:expected #{"an expected"}}}))))
+  (testing "works with regular expressions. Matches only beginning"
+    (is (= :expected (sut/category {:Description "0123 expected"}
+                                   {:categories {:expected #{"[0-3]* expected"}}})))))
+
 (deftest process-tx
   (testing "removes prefix"
     (let [result (sut/process-tx {:Description description :Date unformatted-date}


### PR DESCRIPTION
Restructure the transactions namespace. 
- removing one-off functions that should just be REPL interactions
- move derivations out of the assoc/update around the tx to just return their value. simpler
- move prefixes/categories into params instead of directly read file. easier to test
- add tests